### PR TITLE
ADSDEV-969 update to npm@7

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 		"demo": "http-server"
 	},
 	"engines": {
-		"node": "^8.0.0"
+		"node": "16.x",
+		"npm": "7.x || 8.x"
 	},
 	"devDependencies": {
 		"babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
 	"name": "ft-brand-template",
 	"version": "0.0.0",
 	"scripts": {
-		"demo": "http-server"
+		"demo": "http-server",
+		"preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
 	},
 	"engines": {
 		"node": "16.x",
@@ -21,5 +22,10 @@
 		"webpack": "^4.19.0",
 		"webpack-cli": "^3.1.0"
 	},
-	"dependencies": {}
+	"dependencies": {
+		"check-engines": "^1.5.0"
+	},
+	"volta": {
+		"node": "16.13.0"
+	}
 }


### PR DESCRIPTION
Update engines to `node@16` and `npm@7`.